### PR TITLE
Initialize properly the ruby vm

### DIFF
--- a/RubyEngine.cpp
+++ b/RubyEngine.cpp
@@ -6,6 +6,7 @@ RubyEngine::RubyEngine(const std::string& name)
   ruby_init();
   ruby_script(name.c_str());
   ruby_init_loadpath();
+  ruby_options(0, 0);
 }
 
 RubyEngine::~RubyEngine()


### PR DESCRIPTION
This will allow to have access to features such a read_nonblock method
on IO class instances.
See https://bugs.ruby-lang.org/issues/5174 for details.

Change-Id: Ica5367be6c9d8e90e75686fc16464643f29ca49a