### PR TITLE
Added initial version of RubyIsolator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,43 +1,77 @@
 cmake_minimum_required(VERSION 2.8)
 project(ruby_hook)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fpermissive -std=c++11")
+set(CMAKE_MACOSX_RPATH 1)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fPIC -fpermissive -std=c++11")
 
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(RUBY REQUIRED ruby-2.4)
 
+if(DEFINED ENV{MESOS_SOURCE_DIR})
+  set(MESOS_SOURCE_DIR $ENV{MESOS_SOURCE_DIR})
+  set(MESOS_INCLUDE_DIR ${MESOS_SOURCE_DIR}/include)
+  set(MESOS_BUILD_DIR ${MESOS_SOURCE_DIR}/build) # Convention!
+endif()
+
 if(DEFINED ENV{MESOS_BUILD_DIR})
-  set(MESOS_BUILD_DIR "$ENV{MESOS_BUILD_DIR}")
-else()
+  set(MESOS_BUILD_DIR $ENV{MESOS_BUILD_DIR})
+endif()
+
+if(NOT DEFINED MESOS_BUILD_DIR)
   set(MESOS_BUILD_DIR "${PWD}")
 endif()
 
+if(NOT DEFINED MESOS_INCLUDE_DIR)
+  set(MESOS_INCLUDE_DIR "${MESOS_BUILD_DIR}/include")
+endif()
+
+message( "Build folder is ${MESOS_BUILD_DIR}")
+
+# Required include path lookup in Build dir
+file(GLOB BOOST_SRCH_PATH "${MESOS_BUILD_DIR}/3rdparty/boost-*")
+find_path(BOOST_INCLUDE_DIR NAMES "boost/version.hpp" PATHS ${BOOST_SRCH_PATH} NO_DEFAULT_PATH)
+
+file(GLOB PROTO_SRCH_PATH "${MESOS_BUILD_DIR}/3rdparty/protobuf-*/src")
+find_path(PROTOBUF_INCLUDE_DIR NAMES "google/protobuf/stubs/common.h" PATHS ${PROTO_SRCH_PATH} NO_DEFAULT_PATH)
+
+file(GLOB GLOG_SRCH_PATH "${MESOS_BUILD_DIR}/3rdparty/glog-*/src")
+find_path(GLOG_INCLUDE_DIR NAMES "glog/logging.h" PATHS ${GLOG_SRCH_PATH} NO_DEFAULT_PATH)
+
+file(GLOB PICOJSON_SRCH_PATH "${MESOS_BUILD_DIR}/3rdparty/picojson-*")
+find_path(PICOJSON_INCLUDE_DIR NAMES "picojson.h" PATHS ${PICOJSON_SRCH_PATH} NO_DEFAULT_PATH)
+
 include_directories(
-  "${MESOS_BUILD_DIR}/3rdparty/boost-1.53.0"
-  "${MESOS_BUILD_DIR}/3rdparty/glog-0.3.3/src"
-  "${MESOS_BUILD_DIR}/3rdparty/protobuf-3.3.0/src"
-)
+  ${BOOST_INCLUDE_DIR}
+  ${GLOG_INCLUDE_DIR}
+  ${PROTOBUF_INCLUDE_DIR}
+  ${PICOJSON_INCLUDE_DIR}
+  "${MESOS_SOURCE_DIR}/3rdparty/stout/include"
+  "${MESOS_SOURCE_DIR}/3rdparty/libprocess/include"
+  )
 
 pkg_check_modules(MESOS QUIET mesos)
 
 if (NOT MESOS_FOUND) # Assume build tree has not been installed yet
   set(MESOS_CFLAGS -DPICOJSON_USE_INT64 -D__STDC_FORMAT_MACROS)
-  set(MESOS_INCLUDE_DIRS ${MESOS_BUILD_DIR}/include)
+  set(MESOS_INCLUDE_DIRS ${MESOS_INCLUDE_DIR} ${MESOS_BUILD_DIR}/include)
   set(MESOS_LIBRARY_DIRS ${MESOS_BUILD_DIR}/src/.libs)
   set(MESOS_LIBRARIES mesos)
-  include_directories(
-    "${MESOS_BUILD_DIR}/3rdparty/libprocess/include"
-    "${MESOS_BUILD_DIR}/3rdparty/picojson-1.3.0"
-    "${MESOS_BUILD_DIR}/3rdparty/stout/include"
-  )
 endif()
 
-set(SOURCES
+set(ENGINE_SOURCES
   RubyEngine.cpp
   RubyEngine.hpp
+)
+
+set(HOOK_SOURCES
   RubyHook.cpp
   RubyHook.hpp
+)
+
+set(ISOLATOR_SOURCES
+  RubyIsolator.cpp
+  RubyIsolator.hpp
 )
 
 add_compile_options(${MESOS_CFLAGS} ${RUBY_CFLAGS})
@@ -45,7 +79,9 @@ include_directories(${MESOS_INCLUDE_DIRS} ${RUBY_INCLUDE_DIRS})
 link_directories(${MESOS_LIBRARY_DIRS} ${RUBY_LIBRARY_DIRS})
 link_libraries(${MESOS_LIBRARIES} ${RUBY_LIBRARIES})
 
-add_library(rubyhook SHARED ${SOURCES})
+add_library(rubyengine OBJECT ${ENGINE_SOURCES})
+add_library(rubyhook SHARED $<TARGET_OBJECTS:rubyengine> ${HOOK_SOURCES})
+add_library(rubyisolator SHARED $<TARGET_OBJECTS:rubyengine> ${ISOLATOR_SOURCES})
 
 add_executable(test_hook main.cpp)
 target_include_directories(test_hook PUBLIC ${MESOS_BUILD_DIR}/3rdparty/googletest-release-1.8.0/googletest/include)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Build Instructions
 ------------------
 
 ```shell
-    $ export MESOS_BUILD_DIR=[ directory where Mesos was BUILT, e.g. ~/repos/mesos/build ]
-    $ export PKG_CONFIG_PATH=[ probably the same directory or ${installdir}/lib/pkgconfig ]
+    $ export MESOS_SOURCE_DIR=[ directory of Mesos source code, e.g. ~/repos/mesos/ ]
+    $ export MESOS_BUILD_DIR=[ directory where Mesos was BUILT if different from $MESOS_SOURCE_DIR/build ]
+    $ # export PKG_CONFIG_PATH=[ probably the same directory or ${installdir}/lib/pkgconfig ]
     $ mkdir build
     $ cd build
     $ cmake ..

--- a/RubyEngine.cpp
+++ b/RubyEngine.cpp
@@ -6,7 +6,7 @@ RubyEngine::RubyEngine(const std::string& name)
   ruby_init();
   ruby_script(name.c_str());
   ruby_init_loadpath();
-  ruby_options(0, 0);
+  ruby_options(0, NULL);
 }
 
 RubyEngine::~RubyEngine()

--- a/RubyHook.cpp
+++ b/RubyHook.cpp
@@ -167,7 +167,7 @@ Result<mesos::Environment> RubyHook::slaveExecutorEnvironmentDecorator(
             mesos::Environment env;
             // iterate over the hash and add env from kv-pairs
             // Ruby prototype for hash foreach closure is boggus and requires -fpermissive to compile.
-            rb_hash_foreach(ruby_env, unwrapEnv, (VALUE)&env);
+            rb_hash_foreach(ruby_env, (int (*)(...))unwrapEnv, (VALUE)&env);
             return env; // will *replace* original env (i.e. not merge)
           }
         }
@@ -203,7 +203,7 @@ Result<mesos::Labels> RubyHook::slaveRunTaskLabelDecorator(
           mesos::Labels labels;
           // iterate over the hash and add labels from kv-pairs
           // Ruby prototype for hash foreach closure is boggus and requires -fpermissive to compile.
-          rb_hash_foreach(ruby_labels, unwrapLabels, (VALUE)&labels);
+          rb_hash_foreach(ruby_labels, (int (*)(...))unwrapLabels, (VALUE)&labels);
           return labels; // will *replace* original labels (i.e. not merge)
         }
       }

--- a/RubyIsolator.cpp
+++ b/RubyIsolator.cpp
@@ -1,0 +1,145 @@
+
+#undef NORETURN
+#undef UNREACHABLE
+#include <ruby.h>
+
+#include "RubyIsolator.hpp"
+#include "RubyEngine.hpp"
+
+#include <mesos/mesos.hpp>
+#include <mesos/module/isolator.hpp>
+#include <mesos/slave/isolator.hpp>
+
+#include <process/future.hpp>
+#include <process/owned.hpp>
+#include <process/process.hpp>
+
+#include <stout/try.hpp>
+#include <stout/option.hpp>
+
+using criteo::mesos::RubyIsolator;
+using mesos::ContainerID;
+using mesos::ExecutorInfo;
+using mesos::Parameters;
+using mesos::Parameter;
+using mesos::slave::Isolator;
+using mesos::slave::ContainerConfig;
+
+const std::string RUBY_SCRIPT_NAME = "RubyIsolator";
+const std::string PARAM_SCRIPT_PATH = "script_path";
+
+
+extern "C" {
+
+VALUE ruby_isolator_cleanup(VALUE obj)
+{
+  return rb_funcall(rb_cObject, rb_intern(CleanupCallbackName), 1, obj);
+}
+
+VALUE ruby_isolator_prepare(VALUE obj)
+{
+  return rb_funcall(rb_cObject, rb_intern(PrepareCallbackName), 1, obj);
+}
+
+} // /extern "C"
+
+RubyIsolator::RubyIsolator(const Parameters& parameters)
+  :ruby(RUBY_SCRIPT_NAME)
+{
+  std::string scriptpath;
+  foreach (const Parameter& parameter, parameters.parameter()) {
+    if (parameter.has_key() && parameter.key() == PARAM_SCRIPT_PATH && parameter.has_value()) {
+      scriptpath = parameter.value();
+      break;
+    }
+  }
+
+  if (scriptpath.empty()) {
+    throw std::invalid_argument("missing parameter " + PARAM_SCRIPT_PATH);
+  }
+  if (!ruby.load_script(scriptpath)) {
+    throw std::runtime_error(ruby.handle_exception());
+  }
+}
+
+RubyIsolator::~RubyIsolator(){
+
+}
+
+process::Future<Option<::mesos::slave::ContainerLaunchInfo>> RubyIsolator::prepare(
+    const ContainerID& containerId,
+    const ContainerConfig& containerConfig)
+{
+  LOG(INFO) << "RubyIsolator::prepare( " << stringify(containerId) << ", ..)";
+
+  // Now call Ruby
+  synchronized(mutex){ if (ruby.is_callback_defined(PrepareCallbackName)) {
+    
+    // Gather params for Ruby
+    VALUE h_params = rb_hash_new();
+    rb_hash_aset(h_params, rb_str_new_cstr("container_id"), rb_str_new_cstr(containerId.value().c_str()));
+    rb_hash_aset(h_params, rb_str_new_cstr("user"), 
+      rb_str_new_cstr((containerConfig.has_user() ? containerConfig.user().c_str(): "")));
+    
+    VALUE h_env = rb_hash_new();
+    if( containerConfig.command_info().has_environment() ){
+      auto env = containerConfig.command_info().environment();
+      foreach( auto v, env.variables() ){
+        auto value = v.has_value()? v.value().c_str() : "";
+        auto name = v.name().c_str();
+        rb_hash_aset(h_env, rb_str_new_cstr(name), rb_str_new_cstr(value));
+      }
+    }
+    rb_hash_aset(h_params, rb_str_new_cstr("environment"), h_env); 
+      
+    // call Ruby in a protect env to avoid exception leakage
+    int state = 0;
+    VALUE result = rb_protect(::ruby_isolator_prepare, h_params, &state);
+    //if (state != 0) {
+    //  return Error(ruby.handle_exception());
+    //}
+  }}
+
+  return None();
+}
+
+process::Future<Nothing> RubyIsolator::cleanup(
+    const ContainerID& containerId)
+{
+  LOG(INFO) << "RubyIsolator::cleanup()";
+
+  synchronized(mutex){
+    if (ruby.is_callback_defined(CleanupCallbackName)) {
+      int state = 0;
+      VALUE result = rb_protect(::ruby_isolator_cleanup, Qnil, &state);
+      //if (state != 0) {
+      //  return Error(ruby.handle_exception());
+      //
+      //
+      //
+      //}
+    }
+  }
+  return Nothing();
+}    
+
+// Callback used by registration below...
+static Isolator* createRubyIsolator(const ::mesos::Parameters& parameters)
+{
+  try {
+    return new RubyIsolator(parameters);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "RubyHook error: " << e.what();
+    return nullptr; // already wrapped in a Try<> at calling site
+  }
+}
+
+// Declaration of the isolator
+mesos::modules::Module<Isolator> com_criteo_mesos_RubyIsolator(
+    MESOS_MODULE_API_VERSION,
+    MESOS_VERSION,
+    "Criteo Mesos",
+    "mesos@criteo.com",
+    "Ruby isolator module",
+    nullptr,
+    createRubyIsolator);

--- a/RubyIsolator.hpp
+++ b/RubyIsolator.hpp
@@ -1,0 +1,36 @@
+#ifndef __RUBY_ISOLATOR_MODULE_HPP__
+#define __RUBY_ISOLATOR_MODULE_HPP__
+
+#include "RubyEngine.hpp"
+
+#include <mesos/mesos.hpp>
+#include <mesos/slave/isolator.hpp>
+
+constexpr const char * PrepareCallbackName = "isolator_prepare";
+constexpr const char * CleanupCallbackName = "isolator_cleanup";
+
+namespace criteo {
+  namespace mesos {
+
+    class RubyIsolator : public ::mesos::slave::Isolator
+    {
+      RubyEngine ruby;
+      std::mutex mutex;
+
+    public:
+
+      RubyIsolator(const ::mesos::Parameters& parameters);
+      virtual ~RubyIsolator();
+
+      virtual process::Future<Option<::mesos::slave::ContainerLaunchInfo>> prepare(
+          const ::mesos::ContainerID& containerId,
+          const ::mesos::slave::ContainerConfig& containerConfig);
+
+      virtual process::Future<Nothing> cleanup(
+          const ::mesos::ContainerID& containerId);
+
+    };
+  }
+}
+
+#endif

--- a/rb_isolator.rb
+++ b/rb_isolator.rb
@@ -1,0 +1,23 @@
+
+
+require 'yaml'
+
+def isolator_prepare( params )
+	pid = Process.pid
+	File.open('/tmp/ruby_isolator_stdout.txt','a') do |f| 
+    f.puts "<PREP>"
+		f.puts "MyPID=#{pid}"
+    f.puts "Params (#{params.count}):"
+    f.puts "-----------------"
+    f.puts params.to_s
+    f.puts "</PREP>"
+	end	
+end
+
+def isolator_cleanup( params )
+	pid = Process.pid
+	File.open('/tmp/ruby_isolator_stdout.txt','a') do |f| 
+		f.puts "[CLEAN] MyPID=#{pid}"
+	end	
+end
+


### PR DESCRIPTION
* supports prepare callback
* supports cleanup callback (relevant params to be added)
* builds on OSX!
* the isolator is a new dynamic lib, to be merged with the Hook
  (indeed both are running in same process - mesos-slave),
  so we'll merge the modules, and ruby script,
  as ruby supports a single vm per process